### PR TITLE
Added version to example docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ You will find directions for using our image with various tools.
 ### Docker-Compose
 
 ```yml
+version: "3"
+
 services:
   site:
     command: jekyll serve

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ You will find directions for using our image with various tools.
 
 ```yml
 version: "3"
-
 services:
   site:
     command: jekyll serve


### PR DESCRIPTION
When I copied and pasted the example docker-compose.yaml, and tried it, I saw:

```
$ docker-compose run site
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services: 'site'
```

Adding in a version header makes the example work.
