### PR TITLE
Fix chown invocation

### DIFF
--- a/opts.yml
+++ b/opts.yml
@@ -11,4 +11,4 @@ tags:
   pages: pages
 releases:
   tag:
-    pages: 3.7.3 # 07/07/2018
+    pages: 3.7.3 # 07/09/2018

--- a/repos/jekyll/copy/all/usr/jekyll/bin/entrypoint
+++ b/repos/jekyll/copy/all/usr/jekyll/bin/entrypoint
@@ -22,7 +22,7 @@ if [ "$JEKYLL_UID" != "0" ] && [ "$JEKYLL_UID" != "$(id -u jekyll)" ]; then
   groupmod -g $JEKYLL_GID jekyll
   chown_args=""
 
-  [ "$FULL_CHOWN" ] && chown_args="-r"
+  [ "$FULL_CHOWN" ] && chown_args="-R"
   for d in "$JEKYLL_DATA_DIR" "$JEKYLL_VAR_DIR"; do
     chown $chown_args "$d"
   done


### PR DESCRIPTION
- [ ] I have added or updated the specs.
- [ ] I have verified that the specs pass on my computer.
- [ ] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [ ] This is a source change.


Fix issue introduced by e96998ebbf8325b2b7bf290ce1433f6b8fd1aed7

Hit the following error when running the latest jekyll/jekyll:pages
image

```
docker run --rm -ti -e JEKYLL_UID=`id -u` jekyll/jekyll:pages jekyll build
BusyBox v1.27.2 (2018-06-06 09:08:44 UTC) multi-call binary.

Usage: chown [-RhLHPcvf]... USER[:[GRP]] FILE...

Change the owner and/or group of each FILE to USER and/or GRP

	-R	Recurse
	-h	Affect symlinks instead of symlink targets
	-L	Traverse all symlinks to directories
	-H	Traverse symlinks on command line only
	-P	Don't traverse symlinks (default)
	-c	List changed files
	-v	List all files
	-f	Hide errors
```