### PR TITLE
Add JEKYLL_ROOTLESS option to permit container to run rootless

### DIFF
--- a/repos/jekyll/copy/all/usr/jekyll/bin/entrypoint
+++ b/repos/jekyll/copy/all/usr/jekyll/bin/entrypoint
@@ -3,6 +3,20 @@
 set -e
 
 # --
+# Running rootless means that we force Jekyll to run entirely as 'root'.
+# This is substituted by the container to the uid of the actual user.
+#
+# This is mildly dirty because other parts try and su-exec as 'jekyll'.
+# --
+if [ "$JEKYLL_ROOTLESS" ]; then
+  JEKYLL_UID=0
+  JEKYLL_GID=0
+
+  usermod -u 0 jekyll
+  groupmod -g 0 jekyll
+fi
+
+# --
 : ${JEKYLL_UID:=$(id -u jekyll)}
 : ${JEKYLL_GID:=$(id -g jekyll)}
 

--- a/repos/jekyll/copy/all/usr/jekyll/bin/entrypoint
+++ b/repos/jekyll/copy/all/usr/jekyll/bin/entrypoint
@@ -12,8 +12,8 @@ if [ "$JEKYLL_ROOTLESS" ]; then
   JEKYLL_UID=0
   JEKYLL_GID=0
 
-  usermod -u 0 jekyll
-  groupmod -g 0 jekyll
+  usermod -o -u 0 jekyll
+  groupmod -o -g 0 jekyll
 fi
 
 # --


### PR DESCRIPTION
- [ ] I have added or updated the specs/tests.
- [x] I have verified that the specs/tests pass on my computer.
- [ ] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [x] This is a source change.

## Description

This patch provides a mechanism via which one can pass an envvar JEKYLL_ROOTLESS, which when set will cause Jekyll to run as the root user id of 0.  Doing this permits the container to be run in rootless userspace mode without using uidmap.

Without doing this, uidmap will map the jekyll user in the container into the subuid mapping for the user on the host, resulting in any mounted volumes being chowned to the subuid, breaking access for the original uid.

Setting JEKYLL_UID and JEKYLL_GID to 0 is not sufficient because there are several locations where `su-exec jekyll` is called, resulting in those calls running as the Jekyll user with a default uid of 1000.  While this solution is mildly hacky, it does result in the container only using the original user's uid when run rootless.

<!--
  What issue are you trying to resolve?
  It's always nice to get a brief description.
  Note: you should provide the same in your commit message.
    not everybody uses Github's Web UI.
-->
