### PR TITLE
Update used url to test for Internet connection

### DIFF
--- a/repos/jekyll/copy/all/usr/jekyll/bin/connected
+++ b/repos/jekyll/copy/all/usr/jekyll/bin/connected
@@ -14,7 +14,7 @@ disconnected=$JEKYLL_VAR_DIR/disconnected
 # whether we are connected to the internet.
 #
 
-url=https://www.google.com
+url=https://detectportal.firefox.com
 if wget -q --spider "$url" -O /dev/null 2>/dev/null; then
   su-exec jekyll touch "$connected"
   exit 0


### PR DESCRIPTION
google.com, though a giant url, is not made for connectivity checks and will fail in edge cases (handshake failed in my case). Use https://detectportal.firefox.com instead, which is a domain explicitly made for these checks.