### PR TITLE
Allow JEKYLL_UID/JEKYLL_GID with existing IDs

### DIFF
--- a/repos/jekyll/copy/all/usr/jekyll/bin/entrypoint
+++ b/repos/jekyll/copy/all/usr/jekyll/bin/entrypoint
@@ -25,8 +25,8 @@ export JEKYLL_GID
 #   behavior on OS X.
 #
 if [ "$JEKYLL_UID" != "0" ] && [ "$JEKYLL_UID" != "$(id -u jekyll)" ]; then
-  usermod  -u "$JEKYLL_UID" jekyll
-  groupmod -g "$JEKYLL_GID" jekyll
+  usermod  -o -u "$JEKYLL_UID" jekyll
+  groupmod -o -g "$JEKYLL_GID" jekyll
   chown_args=""
 
   [ "$FULL_CHOWN" ] && chown_args="-R"


### PR DESCRIPTION
Some standard UIDs/GIDs already exist in the docker image, e.g. nobody, nogroup, users. 

If `JEKYLL_UID/JEKYLL_GID` is used with a numeric ID matching one of those, then entrypoint aborts with an error like `"groupmod: GID '33' already exists"`.

This commit adds the `-o` option to `usermod/groupmod` to allow non-unique IDs.

I ran into this problem when using `JEKYLL_GID=33` which is `www-data` on my host system and `xfs` in the docker image.
I've tested this change successfully and can't see a problem with using non-unique IDs for jekyll in general.

There is some code near the end of entrypoint that already uses the `-o` option with `usermod/groupmod` in the `JEKYLL_ROOTLESS` case. It might be possible to get rid of this extra call to `usermod/groupmod`, but I haven't tried.