### PR TITLE
Upgrade Jekyll to 4.2.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,19 +13,19 @@ jobs:
       matrix:
         env:
           -
-            - jekyll:4.1.0
+            - jekyll:4.2.0
             - jekyll:stable
             - jekyll:latest
             - jekyll:4.0
             - jekyll:4
           -
-            - builder:4.1.0
+            - builder:4.2.0
             - builder:stable
             - builder:latest
             - builder:4.0
             - builder:4
           -
-            - minimal:4.1.0
+            - minimal:4.2.0
             - minimal:stable
             - minimal:latest
             - minimal:4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
     # --
     env: "\
       DOCKER_REPO='\
-        jekyll:4.1.0 \
+        jekyll:4.2.0 \
         jekyll:stable \
         jekyll:latest \
         jekyll:pages \
@@ -43,7 +43,7 @@ jobs:
   # --
   - env: "\
       DOCKER_REPO='\
-        builder:4.1.0 \
+        builder:4.2.0 \
         builder:stable \
         builder:latest \
         jekyll:builder \
@@ -57,7 +57,7 @@ jobs:
   # --
   - env: "\
       DOCKER_REPO='\
-        minimal:4.1.0 \
+        minimal:4.2.0 \
         minimal:stable \
         minimal:latest \
         jekyll:minimal \

--- a/opts.yml
+++ b/opts.yml
@@ -1,12 +1,12 @@
 base_image: ruby:2.7.1-alpine3.11
 user: jekyll
 aliases:
-  latest: 4.1.0
-  stable: 4.1.0
-  4.0: 4.1.0
-  4: 4.1.0
+  latest: 4.2.0
+  stable: 4.2.0
+  4.0: 4.2.0
+  4: 4.2.0
 tags:
-  4.1.0: stable
+  4.2.0: stable
   pages: pages
 releases:
   tag:


### PR DESCRIPTION
Replaces 4.1.0 with 4.2.0 as stable.