### PR TITLE
Exit Container Cleanly

### DIFF
--- a/repos/jekyll/copy/all/usr/jekyll/bin/jekyll
+++ b/repos/jekyll/copy/all/usr/jekyll/bin/jekyll
@@ -2,6 +2,8 @@
 [ "$DEBUG" = "true" ] && set -x
 set -e
 
+trap 'kill -SIGTERM ${!}' TERM
+
 args=$(default-args "$@")
 
 #
@@ -33,4 +35,4 @@ sup_args=""
 exe=$BUNDLE_BIN/jekyll
 [ "$JEKYLL_DOCKER_TAG" = "pages" ] && sup_args="-r github-pages"
 [ -x "$exe" ] && exec su-exec jekyll bundle exec ruby $sup_args $exe $args
-su-exec jekyll ruby $sup_args "$GEM_BIN/jekyll" $args
+su-exec jekyll ruby $sup_args "$GEM_BIN/jekyll" $args & wait ${!}


### PR DESCRIPTION
By passing SIGTERM to the root process's child, we ensure that the container will exit cleanly. Otherwise, Docker will send SIGKILL after waiting 10 seconds. This fix also has the effect of greatly increasing the speed of container restarts. 

Further reading:
* https://docs.docker.com/compose/faq/#why-do-my-services-take-10-seconds-to-recreate-or-stop
* https://medium.com/@gchudnov/trapping-signals-in-docker-containers-7a57fdda7d86
